### PR TITLE
Make run-clang-format.sh work well in before-submit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,19 +67,8 @@ jobs:
       - name: Run formatting style check
         run: |
           clang-format-18 --version
-          CLANG_FORMAT=clang-format-18 scripts/run-clang-format.sh
-          git diff > /tmp/format-diff
-          if [ -s "/tmp/format-diff" ]; then
-            echo "Difference to optimal formatting"
-            cat /tmp/format-diff
-            echo
-            echo "=================== To Fix ==========================="
-            echo "Run scripts/run-format.sh"
-            echo "then"
-            echo "  git commit -a --amend"
-            echo "  git push -f"
-            exit 1
-          fi
+          RUNNING_IN_CI=1 CLANG_FORMAT=clang-format-18 \
+            scripts/run-clang-format.sh
 
   ClangTidy:
     runs-on: ubuntu-24.04
@@ -117,4 +106,3 @@ jobs:
           clang-tidy-18 --version
           CLANG_TIDY=clang-tidy-18 scripts/run-clang-tidy-cached.cc \
             || ( cat fpga-assembler_clang-tidy.out ; exit 1)
-

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -6,6 +6,7 @@ FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
 
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
 BUILDIFIER=${BUILDIFIER:-buildifier}
+RUNNING_IN_CI=${RUNNING_IN_CI:-0}
 
 ${CLANG_FORMAT} --version
 
@@ -19,17 +20,21 @@ if command -v ${BUILDIFIER} >/dev/null; then
   ${BUILDIFIER} -lint=fix MODULE.bazel $(find . -name BUILD -o -name "*.bzl")
 fi
 
-# Check if we got any diff
-git diff > ${FORMAT_OUT}
+# If in CI, we want to report changes, as we don't expect them
+if [ "$RUNNING_IN_CI" -eq 1 ]; then
+    # Check if we got any diff
+    git diff > ${FORMAT_OUT}
 
-if [ -s ${FORMAT_OUT} ]; then
-   echo "Style not matching"
-   echo "Run"
-   echo "  .github/bin/run-clang-format.sh"
-   echo "-------------------------------------------------"
-   echo
-   cat ${FORMAT_OUT}
-   exit 1
+    if [ -s ${FORMAT_OUT} ]; then
+	echo "Style not matching"
+	echo "Run"
+	echo "  scripts/run-clang-format.sh"
+	echo "and amend PR."
+	echo "-------------------------------------------------"
+	echo
+	cat ${FORMAT_OUT}
+	exit 1
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
In scripts/before-submit.sh, we do not want to get an error when anything is formatted, we just want it to be done.

In the CI, however, we want to use the same script and have it fail if not.