### PR TITLE
MODULE.bazel: Update rules_cc and bant.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,12 +5,10 @@ module(
 
 # Bazel C/C++ language rules and deps.
 bazel_dep(name = "rules_cc", version = "0.0.16")
-
-# Until this is merged: https://github.com/bazelbuild/rules_cc/pull/306
 git_override(
     module_name = "rules_cc",
-    commit = "4d6035a37b3211dec0fa5c070c7e9aac0e05186e",
-    remote = "https://github.com/lromor/rules_cc.git",
+    commit = "d74915024017250e46d95e91a3defc34174effe0",
+    remote = "https://github.com/bazelbuild/rules_cc",
 )
 
 bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
@@ -19,4 +17,4 @@ bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20241007")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # compilation DB; build_cleaner
-bazel_dep(name = "bant", version = "0.1.14", dev_dependency = True)
+bazel_dep(name = "bant", version = "0.2.0", dev_dependency = True)


### PR DESCRIPTION
https://github.com/bazelbuild/rules_cc/pull/306 has been merged, so we can use unstable from upstream now.

Also, upgrade to latest bant version.