### PR TITLE
Fix handling of features above 32 bits or with offset

### DIFF
--- a/fpga/assembler.cc
+++ b/fpga/assembler.cc
@@ -110,7 +110,7 @@ static absl::Status ProcessFasmFeatures(
     // Select only bit addresses with value bit set to 1.
     for (int addr = 0; addr < tile_feature.width; ++addr) {
       const unsigned feature_addr = (addr + tile_feature.start_bit);
-      const bool value = bits & (1 << feature_addr);
+      const bool value = bits & (uint64_t(1) << addr);
       if (value) {
         db.ConfigBits(
           tile_name, feature, feature_addr,


### PR DESCRIPTION
There were two bugs spotted here: 

 - `(1 << feature_addr)` was only a 32 bit value because neither `1` nor `feature_addr` were 64 bits, so 64 bit features would be generated wrongly
 - `bits` is not shifted by `start_bit`, so the test of it should start from 0 rather than `start_bit`

With this I can get the himbaechel-xilinx blinky example to correctly build for arty-a35t using this for assembly.